### PR TITLE
Renamed Sensors for Improved Contextuality (Closes #36)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ import { samplers, fmSynths } from './instruments.js';
 // HTML template for a sound module
 import { createSoundModuleTemplate } from './soundModule.js';
 
+// Import sensor display name function
+import { sensorDisplayName } from "./sensorNames.js";
+
 // Menu items for the instruments
 let instrumentsMenuItems = [];
 
@@ -1052,7 +1055,7 @@ function initializeModuleSelects(module, data) {
       if (key === '_id' || key === 'Timestamp' || key === 'WiFi') return;
       let option = document.createElement('option');
       option.value = key;
-      option.text = key;
+      option.textContent = sensorDisplayName(key);
       sensorsSelect.appendChild(option);
     });
 

--- a/sensorNames.js
+++ b/sensorNames.js
@@ -1,0 +1,26 @@
+export function sensorDisplayName(rawKey) {
+  if (!rawKey) return rawKey;
+
+  // any SHT31 or SHT31_# is matched here
+  const sht = rawKey.match(/^SHT31(?:_(\d+))?$/);
+  if (sht) {
+    return sht[1] ? `Temperature/Humidity_${sht[1]}` : "Temperature/Humidity"; // if no number, return base name
+  }
+
+  // dictionary mapping for other sensors
+  const map = {
+    TSL2591: "Solar Radiation",
+    MS5803_119: "Device Pressure",
+    MS5803_118: "Outside Pressure",
+    TippingBucket: "Rainfall",
+    Teros10: "Sail Moisture",
+    A55311: "Magnetic Encoder",
+    DFR_MultiGas_0: "Hydrogen Sulfide",
+    DFR_MultiGas_1: "Sulfur Dioxide",
+    DFR_MultiGas_2: "Ozone",
+    Sen55: "Air Quality",
+    T6793: "CO2",
+  };
+
+  return map[rawKey] ?? rawKey; // backwards compatible fallback
+}


### PR DESCRIPTION
Sensors were renamed via a naming library for users to better understand what given readings are being measured on. Furthermore, I added backwards compatibility for the purpose of new sensors that might be added. Here are the renaming conventions that were made:

- Any SHT31 sensor should be renamed to "Temperature/Humidity"
- If SHT31_#, then "Temperature/Humidity_#"
- TSL2591 --> Solar Radiation
- MS5803_119 --> Device Pressure
- MS5803_118 --> Outside Pressure
- TippingBucket --> Rainfall
- Teros10 --> Sail Moisture
- A55311 --> Magnetic Encoder
- DFR_MultiGas_0 --> Hydrogen Sulfide
- DFR_MultiGas_1 --> Sulfur Dioxide
- DFR_MultiGas_2 --> Ozone
- Sen55 --> Air Quality
- T6793 --> C02

**Closes #36** 