### PR TITLE
User walkthrough modals implementation for first-time users (Closes #60)

### DIFF
--- a/index.js
+++ b/index.js
@@ -898,6 +898,8 @@ function startFirstTimeOnboarding() {
     card.remove();
     document.getElementById('dataSourceModal').style.display = 'none';
     document.getElementById('dateTimeModal').style.display = 'none';
+    document.getElementById('dataSourceModal').classList.remove('onboarding-modal-active');
+    document.getElementById('dateTimeModal').classList.remove('onboarding-modal-active');
     if (markComplete) {
       setOnboardingComplete();
     }
@@ -919,9 +921,11 @@ function startFirstTimeOnboarding() {
 
     if (dataSourceModal) {
       dataSourceModal.style.display = step.showDataSourceModal ? 'flex' : 'none';
+      dataSourceModal.classList.toggle('onboarding-modal-active', !!step.showDataSourceModal);
     }
     if (dateTimeModal) {
       dateTimeModal.style.display = step.showDateTimeModal ? 'flex' : 'none';
+      dateTimeModal.classList.toggle('onboarding-modal-active', !!step.showDateTimeModal);
     }
 
     const targets = (step.selectors || [])

--- a/sensorNames.js
+++ b/sensorNames.js
@@ -10,8 +10,8 @@ export function sensorDisplayName(rawKey) {
   // dictionary mapping for other sensors
   const map = {
     TSL2591: "Light",
-    MS5803_119: "Hydrostatic Pressure",
-    MS5803_118: "Atmospheric Pressure",
+    MS5803_119: "Hydrostatic",
+    MS5803_118: "Atmospheric",
     TippingBucket: "Rainfall Gauge",
     Teros10: "Soil Moisture",
     A55311: "Magnetic Encoder",

--- a/style.css
+++ b/style.css
@@ -151,6 +151,24 @@ nav#nav ul li a {
   border-radius: 6px;
 }
 
+.modal.onboarding-modal-active {
+  z-index: 12001;
+}
+
+.modal.onboarding-modal-active .modal-content,
+.modal.onboarding-modal-active .modal-form,
+.modal.onboarding-modal-active .form-group,
+.modal.onboarding-modal-active #presetElements,
+.modal.onboarding-modal-active #databaseElements,
+.modal.onboarding-modal-active #deviceElements,
+.modal.onboarding-modal-active #confirmDataSource,
+.modal.onboarding-modal-active #confirmDateTime {
+  position: relative;
+  z-index: 12002;
+  opacity: 1;
+  filter: none;
+}
+
 #speedOptions.onboarding-highlight {
   box-shadow: none;
 }


### PR DESCRIPTION
At first glance, our website could confuse a first-time user in figuring how to navigate Ear2Earth and all its functionalities. Since Ear2Earth didn't have guidance regarding that matter, the team believes having this user walkthrough will be beneficial for not only a first-time user's understandability, but for user retention.

Thus, I implemented this feature--including 19 modals--that walkthrough the major features of Ear2Earth, and in each modal, there are short descriptions that breakdown its significance.


Closes #60 