### PR TITLE
Date range functionality refactored for usability purposes and 'Last Packets' mode has auto-resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,9 +119,9 @@
             <!-- Metadata View Button -->
             <!-- Opens modal to display packet metadata information -->
             <div class="group">
-              <button id="metadataButton" class="pill-btn">
-                <i data-lucide="codeXml"></i>
-                View Metadata
+              <button id="metadataButton" class="pill-btn icon-btn">
+                <span data-lucide="codeXml" id="metadataIcon"></span>
+                <span id="metadataTxt">View Metadata</span>
               </button>
               <!-- Help/Info button for metadata -->
               <button id="metadataHelp" class="icon-btn" title="Help">
@@ -290,6 +290,11 @@
       </div>
 
       <div id="popover1" class= "popover1" style="display:none;">
+          <button class="popover-close">&times;</button>
+        <div class="popover-body"></div>
+      </div>
+
+      <div id="popover2" class= "popover2" style="display:none;">
           <button class="popover-close">&times;</button>
         <div class="popover-body"></div>
       </div>

--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ var retrievedData;
 // Array to hold x-axis data for each plot
 let plotXData = {};
 
+// Track if onboarding is in progress
+let openPresetBtn;
+
 // Undo/Redo state management
 let historyStack = [];
 let historyIndex = -1;
@@ -87,7 +90,13 @@ function captureState() {
     bpm: document.getElementById('bpm')?.value,
     masterVolume: document.getElementById('masterVolume')?.value,
     numPackets: document.getElementById('numpackets')?.value,
-    prescaler: document.getElementById('prescaler')?.value
+    prescaler: document.getElementById('prescaler')?.value,
+    presetButtonText: document.getElementById('openPresetModal')?.textContent.trim(),
+    startTime: document.getElementById('startTime')?.value,
+    endTime: document.getElementById('endTime')?.value,
+    dateRangeText: document.getElementById('dateRangeText')?.textContent.trim(),
+    packetOption: document.querySelector('input[name="packetOption"]:checked')?.value,
+    retrievedData: retrievedData ? [...retrievedData] : null
   };
 }
 
@@ -122,8 +131,22 @@ function restoreState(state) {
   try {
     // Stop any playback
     stopSynths();
+
+    retrievedData = state.retrievedData || null;
     
     // Restore global settings
+    if (state.presetButtonText === '' || state.presetButtonText.includes('Select a Preset')) {
+      openPresetBtn.innerHTML = '';
+      const iconEl = document.createElement('i');
+      iconEl.setAttribute('data-lucide', 'folder-search');
+      openPresetBtn.appendChild(iconEl);
+      openPresetBtn.append(' Select Preset');
+      lucide.createIcons();
+      const modalPresetDropdown = document.getElementById('modalPreset');
+      if (modalPresetDropdown) modalPresetDropdown.value = 'default';
+    } else {
+      openPresetBtn.textContent = state.presetButtonText;
+    }
     if (state.database) document.getElementById('databases').value = state.database;
     if (state.device) document.getElementById('devices').value = state.device;
     if (state.bpm) {
@@ -134,6 +157,20 @@ function restoreState(state) {
     if (state.masterVolume) document.getElementById('masterVolume').value = state.masterVolume;
     if (state.numPackets) document.getElementById('numpackets').value = state.numPackets;
     if (state.prescaler) document.getElementById('prescaler').value = state.prescaler;
+
+    // Restore date range
+    if (state.startTime !== undefined) document.getElementById('startTime').value = state.startTime;
+    if (state.endTime !== undefined) document.getElementById('endTime').value = state.endTime;
+    if (state.dateRangeText !== undefined) document.getElementById('dateRangeText').textContent = state.dateRangeText;
+
+    // Restore packet option radio + show/hide inputs
+    if (state.packetOption) {
+      const radio = document.querySelector(`input[name="packetOption"][value="${state.packetOption}"]`);
+      if (radio) radio.checked = true;
+      const isLastX = state.packetOption === 'lastXPackets';
+      document.getElementById('numpacketsInput').style.display = isLastX ? '' : 'none';
+      document.getElementById('skipPackets').style.display = isLastX ? '' : 'none';
+    }
     
     // Remove all modules
     const modulesContainer = document.getElementById('modulesContainer');
@@ -166,6 +203,18 @@ function restoreState(state) {
       // Replot if data exists
       if (retrievedData) {
         plot(index);
+      } else {
+        const plotDiv = module.querySelector('.plot');
+        if (plotDiv) {
+          try { 
+            Plotly.purge(plotDiv);
+           } catch(e) {}
+        }
+      }
+
+      // Clear the global timeline if no data
+      if (!retrievedData) {
+        try { Plotly.purge(document.getElementById('globalTimeline')); } catch(e) {}
       }
     });
     
@@ -182,13 +231,13 @@ function updateUndoRedoButtons() {
   const redoBtn = document.getElementById('redo');
   
   if (undoBtn) {
-    undoBtn.disabled = historyIndex <= 0;
+    undoBtn.disabled = historyStack.length === 0 || historyIndex <= 0;
     undoBtn.style.opacity = historyIndex <= 0 ? '0.5' : '1';
     undoBtn.style.cursor = historyIndex <= 0 ? 'not-allowed' : 'pointer';
   }
   
   if (redoBtn) {
-    redoBtn.disabled = historyIndex >= historyStack.length - 1;
+    redoBtn.disabled = historyStack.length === 0 || historyIndex >= historyStack.length - 1;
     redoBtn.style.opacity = historyIndex >= historyStack.length - 1 ? '0.5' : '1';
     redoBtn.style.cursor = historyIndex >= historyStack.length - 1 ? 'not-allowed' : 'pointer';
   }
@@ -214,7 +263,10 @@ async function addSoundModule() {
   // Populate the sound types dropdown
   const soundTypesSelect = newModule.querySelector('.soundTypes');
   soundTypesSelect.innerHTML = instrumentsMenuItems.join('');
-  soundTypesSelect.value = 'retro'; // Set default value
+  soundTypesSelect.value = 'harp'; // Set default value
+
+  const tessituraSelect = newModule.querySelector('.tessitura');
+  tessituraSelect.value = "Tenor";
 
   // Set default sustain notes for the new module
   sustainNotes[moduleId] = true; // Default to true
@@ -310,7 +362,10 @@ function attachVolumeListener(soundModule) {
   const volumeSlider = soundModule.querySelector('.volume');
   volumeSlider.addEventListener('input', event => {
     const volumeValue = parseFloat(event.target.value);
-    gainNodes[soundModules.indexOf(soundModule)].volume.value = volumeValue;
+    const idx = soundModules.indexOf(soundModule);
+    if (gainNodes[idx]) {
+      gainNodes[idx].volume.value = volumeValue;
+    }
     console.log(`Volume for ${soundModule.id} set to ${volumeValue} dB`);
   });
 }
@@ -343,7 +398,7 @@ function attachCollapseListener(soundModule) {
 
   // 1. Setup an Observer to watch for height changes in this specific module
   const resizeObserver = new ResizeObserver(() => {
-    if (plotDiv && (plotDiv.data || plotDiv.layout)) {
+    if (plotDiv && plotDiv.offsetParent != null && (plotDiv.data || plotDiv.layout)) {
       Plotly.Plots.resize(plotDiv);
     }
   });
@@ -1323,7 +1378,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('dataSourceModal');
   const closeBtn = document.querySelector('.close-modal');
   const confirmBtn = document.getElementById('confirmDataSource');
-  const openPresetBtn = document.getElementById('openPresetModal');  // Changed this line
+  openPresetBtn = document.getElementById('openPresetModal');  
   const modalPresetDropdown = document.getElementById('modalPreset');
 
   // Show modal when clicking the preset button
@@ -1362,6 +1417,7 @@ document.addEventListener('DOMContentLoaded', () => {
         openPresetBtn.textContent = `${selectedDatabase} - ${selectedDevice}`;
       }
       modal.style.display = 'none';
+      saveState();
     } else {
       alert('Please select both a database and a device');
     }
@@ -1406,7 +1462,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const lastXPacketsRadio = document.getElementById('lastXPackets');
   lastXPacketsRadio.addEventListener('change', () => {
     if (lastXPacketsRadio.checked) {
-      resetDateRangeState();
+      // Clear the date range display
+      dateRangeText.textContent = 'Date Range';
+      // Clear the hidden inputs
+      startTimeInput.value = '';
+      endTimeInput.value = '';
+      prescalerInput.value = '1';
+      // Clear the modal inputs
+      modalStartTime.value = '';
+      modalEndTime.value = '';
+      modalPrescaler.value = '1';
+      // Reset confirmation 
+      dateRangeConfirmed = false;
+      saveState();
     }
   });
 
@@ -1416,7 +1484,10 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Only reset if user hasn't confirmed a date range
     if (!dateRangeConfirmed) {
-      resetToLastPacketsMode();
+      lastXPacketsRadio.checked = true;
+      document.getElementById('numpacketsInput').style.display = '';
+      document.getElementById('skipPackets').style.display = '';
+      dateRangeText.textContent = 'Date Range';
     }
   });
 
@@ -1453,6 +1524,7 @@ document.addEventListener('DOMContentLoaded', () => {
     dateRangeText.textContent = `${startDate} - ${endDate}`;
     dateRangeConfirmed = true; // Mark as confirmed
     dateTimeModal.style.display = 'none';
+    saveState();
     updateDateRangeModalButton();
 
     if (timeRangeRadio.checked) {
@@ -1481,6 +1553,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const popover1Body = popover1.querySelector('.popover-body');
   const popover1Close = popover1.querySelector('.popover-close');
 
+  const popover2 = document.getElementById('popover2');
+  const popover2Body = popover2.querySelector('.popover-body');
+  const popover2Close = popover2.querySelector('.popover-close');
+
 
   function showPopover(button, content) {
     // Set content
@@ -1502,6 +1578,13 @@ document.addEventListener('DOMContentLoaded', () => {
     popover1.style.top = (rect.bottom + 8) + 'px';
   }
 
+  function showPopover2(button, content) {
+    popover2Body.textContent = content;
+    const rect = button.getBoundingClientRect();
+    popover2.style.display = 'block';
+    popover2.style.left = rect.left + 'px';
+    popover2.style.top = (rect.bottom + 8) + 'px';
+  }
 
   function hidePopover() {
     popover.style.display = 'none';
@@ -1511,8 +1594,17 @@ document.addEventListener('DOMContentLoaded', () => {
     popover1.style.display = 'none';
   }
 
+  function hidePopover2() {
+    popover2.style.display = 'none';
+  }
+
   popoverClose.addEventListener('click', hidePopover);
   popover1Close.addEventListener('click', hidePopover1);
+  popover2Close.addEventListener('click', hidePopover2);
+
+  // Hide when leaving the popover itself
+  popover.addEventListener('mouseleave', hidePopover);
+  popover1.addEventListener('mouseleave', hidePopover1);
 
   // Close when clicking outside
   document.addEventListener('click', (e) => {
@@ -1522,24 +1614,49 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!popover1.contains(e.target) && !e.target.closest('.icon-btn')) {
       hidePopover1();
     }
+    if (!popover2.contains(e.target) && !e.target.closest('.icon-btn')) {
+      hidePopover2();
+    }
   });
 
   const metadataHelp = document.getElementById('metadataHelp');
   const refreshHelp = document.getElementById('refreshHelp');
   
   if (metadataHelp) {
-    metadataHelp.addEventListener('click', (e) => {
+    metadataHelp.addEventListener('mouseenter', (e) => {
       e.stopPropagation();
       showPopover(e.currentTarget, 'Metadata shows device deployment information including date, location (latitude/longitude), and database owner.');
     });
+    metadataHelp.addEventListener('mouseleave', hidePopover);
   }
   
   if (refreshHelp) {
-    refreshHelp.addEventListener('click', (e) => {
+    refreshHelp.addEventListener('mouseenter', (e) => {
       e.stopPropagation();
       showPopover1(e.currentTarget, 'Reloads the latest packet data from your selected source while preserving your workspace configuration and tracks.');
     });
+    refreshHelp.addEventListener('mouseleave', hidePopover1);
   }
+
+  metadataBtn.addEventListener("click", (e) => {
+  e.stopPropagation();
+
+  if (!metadata) {
+    showPopover2(e.currentTarget, "No available metadata");
+    isMetadataDisplayed = true;
+    return;
+  }
+
+  const metadataContent = `
+    Deployment Date: ${metadata.deployment_date}\n
+    Latitude: ${metadata.latitude}\n
+    Longitude: ${metadata.longitude}\n
+    Owner: ${metadata.owner}\n
+    `;
+
+  showPopover2(e.currentTarget, metadataContent);
+  isMetadataDisplayed = true;
+});
 
   // ====== UNDO/REDO button functionality ======
   const undoBtn = document.getElementById('undo');
@@ -1611,6 +1728,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Fetch databases and populate the dropdown
   fetchDatabases();
+
+  // Set null before first module is created 
+  retrievedData = null;
 
   // Create one soundModule on startup
   addSoundModule();
@@ -1700,21 +1820,33 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
   // Handle selection from the named dropdown
+
 // Handle selection from the named dropdown
   const modalPreset = document.getElementById("modalPreset");
   modalPreset.addEventListener('change', async e => {
     handleDatasetChange(e);
     isMetadataDisplayed = false;
     metadataContainer.style.display = 'none';
-    
-    metadataBtn.style.display = "block";
-    metadataBtn.textContent = 'Loading...';
+
+    const metadataTxt = metadataBtn.querySelector('#metadataTxt');
+    let metadataIcon = metadataBtn.querySelector('#metadataIcon');
+
+    metadataIcon.setAttribute("data-lucide", "loader");
+    metadataTxt.textContent = 'Loading...';
+    lucide.createIcons();
     metadata = await retrieveMetadata();
 
+
     if (metadata == null) {
-      metadataBtn.textContent = 'No Metadata'
+      metadataIcon = metadataBtn.querySelector('#metadataIcon');
+      metadataIcon.setAttribute("data-lucide", "circle-off");
+      lucide.createIcons();
+      metadataTxt.textContent = 'No Metadata';
     } else {
-      metadataBtn.textContent = 'View Metadata';
+      metadataIcon = metadataBtn.querySelector('#metadataIcon');
+      metadataIcon.setAttribute("data-lucide", "codeXml");
+      lucide.createIcons();
+      metadataTxt.textContent = 'View Metadata';
     }
 
     return;
@@ -1723,7 +1855,7 @@ document.addEventListener('DOMContentLoaded', () => {
   workspaceHasData = false;
   updateClearWorkspaceButton();
 
-  saveState(); // Save initial state for undo/redo
+  //saveState(); // Save initial state for undo/redo
   updateUndoRedoButtons();
   
   if (shouldRunOnboarding()) {
@@ -1885,8 +2017,8 @@ document.getElementsByName('packetOption').forEach(radio => {
   radio.addEventListener('change', async function () {
     // If "lastXPackets" is selected, show the "numpackets" and "prescaler" input fields and hide the "startTime" and "endTime" input fields
     if (this.value === 'lastXPackets') {
-      numpacketsInput.style.display = 'block';
-      skipPackets.style.display = 'block';
+      numpacketsInput.style.display = '';
+      skipPackets.style.display = '';
       updateDateRangeModalButton();
       //timeInputs.style.display = 'none';
     }
@@ -1930,7 +2062,7 @@ document.getElementsByName('packetOption').forEach(radio => {
       });
     } else {
       // added 10/26
-      numpackets.style.display = 'block';
+      numpacketsInput.style.display = '';
     
       resetDates();
     }
@@ -2895,57 +3027,4 @@ async function retrieveMetadata() {
   }
 }
 
-metadataBtn.onclick = async function () {
-  const metadataContainer = document.getElementById('metadataContainer');
 
-  if (isMetadataDisplayed) {
-    metadataContainer.style.display = 'none';
-    isMetadataDisplayed = false;
-    metadataBtn.textContent = 'View Metadata';
-    return;
-  }
-
-  if (metadata == null) {
-    return;
-  }
-
-  metadataBtn.textContent = "Loading...";
-  metadataContainer.style.display = 'flex';
-  metadataBtn.textContent = "Close";
-
-  if (metadata == null) {
-    metadataContainer.innerHTML = `
-        <h3>No metadata :(</h3>
-        `;
-  } else {
-    let metadataDeploymentDate = metadata['deployment_date'];
-    let metadataLatitude = metadata['latitude'];
-    let metadataLongitude = metadata['longitude'];
-    let metadataOwner = metadata['owner'];
-
-    metadataContainer.innerHTML = `
-        <div id="metadataSection">
-          <h3>Deployment Date: </h3>
-          <p id="metadataDeploymentDate">${metadataDeploymentDate}</p>
-        </div>
-
-        <div id="metadataSection">
-          <h3>Latitude: </h3>
-          <p id="metadataLatitude">${metadataLatitude}</p>
-        </div>
-
-        <div id="metadataSection">
-          <h3>Longitude: </h3>
-          <p id="metadataLongitude">${metadataLongitude}</p>
-        </div>
-
-        <div id="metadataSection">
-          <h3>Owner: </h3>
-          <p id="metadataOwner">${metadataOwner}</p>
-        </div>
-        `;
-  }
-  
-  isMetadataDisplayed = true;
-  return;
-};

--- a/style.css
+++ b/style.css
@@ -362,6 +362,7 @@ TOP MENU
   gap: calc(var(--tb-scale) * 3px);
   height: var(--tb-h);
   margin: 0;
+  justify-content: space-between;
 }
 
 #numpacketsInput,
@@ -380,6 +381,7 @@ TOP MENU
   white-space: nowrap;
   margin: 0;
   box-sizing: border-box;
+  flex-shrink: 0;
 }
 
 #numpacketsInput label {
@@ -457,6 +459,10 @@ TOP MENU
   flex-shrink: 0;
 }
 
+#metadataButton:hover {
+  background-color: var(--hover-grey);
+}
+
 .icon-btn {
   width:  calc(var(--tb-scale) * 29px);
   height: calc(var(--tb-scale) * 29px);
@@ -484,7 +490,7 @@ TOP MENU
   border-radius: var(--tb-radius);
   cursor: pointer;
   position: relative;
-  z-index: 10;
+  z-index: 0;
   background-color: var(--main-grey);
   display: flex;
   align-items: center;
@@ -504,6 +510,26 @@ TOP MENU
   width:  calc(var(--tb-scale) * 12.5px);
   height: calc(var(--tb-scale) * 12.5px);
   flex-shrink: 0;
+}
+
+#metadataContainer {
+  display: none;
+  margin: 0 0 10px 0;
+  flex-direction: row;
+  justify-content: space-evenly;
+
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background-color: #fff;
+}
+
+#metadataContainer h3 {
+  font-weight: bold;
+  font-size: 16px;
+}
+
+#metadataContainer p {
+  font-size: 12px;
 }
 
 /* =====================================================
@@ -537,7 +563,7 @@ TOP MENU
   align-items: center;
   justify-content: center;
   padding: 0 var(--tb-pad);
-  gap: calc(var(--tb-scale) * 4px);
+  gap: calc(var(--tb-scale) * 12px);
   height: var(--tb-h);
 }
 
@@ -625,7 +651,7 @@ TOP MENU
   text-align: center;
   color: #000000;
   position: absolute;
-  margin-top: calc(var(--tb-scale) * -10px);
+  margin-bottom: calc(var(--tb-scale) * 18px);
   margin-left: calc(var(--tb-scale) * 18px);
 }
 
@@ -633,7 +659,7 @@ TOP MENU
   accent-color: var(--standard-blue);
   width: calc(var(--tb-scale) * 135px);
   height: calc(var(--tb-scale) * 6px);
-  margin-top: calc(var(--tb-scale) * -8px);
+  margin-top: calc(var(--tb-scale) * 0px);
 }
 
 /* Speed options (1x 2x 4x 8x) */
@@ -690,6 +716,7 @@ TOP MENU
   height: var(--tb-h);
   width: calc(var(--tb-scale) * 57px);
   margin: 0;
+  flex-shrink: 0;
 }
 
 .icon-btn-small {
@@ -736,7 +763,7 @@ TOP MENU
   height: var(--tb-h);
   width:  calc(var(--tb-scale) * 100px);
   transition: all 0.2s ease;
-  white-space: nowrap;
+  white-space: normal;
   flex-direction: column;
   justify-content: center;
   text-align: center;
@@ -1268,7 +1295,7 @@ TOP MENU
 /* =====================================================
    POPOVER
 ===================================================== */
-.popover, .popover1 {
+.popover, .popover1, .popover2 {
   position: absolute;
   background: white;
   border: 1px solid #ccc;
@@ -1352,6 +1379,7 @@ TOP MENU
 
 .popover-body { 
   margin-top: 2px; 
+  white-space: pre-line;
 }
 
 /* =====================================================


### PR DESCRIPTION
Made it so that if a user changes to another preset, switches devices, or switches a database, the date range will dynamically update to the respective start and end dates. In addition, I implemented auto-resizing for when a user switches to 'Date Range' mode so the 'Date Range' and 'Last Packets' buttons are always the same size. 

This simplifies usability for the user and improves aesthetic.

Closes #89 