### PR TITLE
Fixed button resizing when date range selected

### DIFF
--- a/index.js
+++ b/index.js
@@ -1976,6 +1976,8 @@ document.addEventListener('DOMContentLoaded', () => {
       dateRangeConfirmed = false;
       document.querySelector('#dateRangeLabel svg').style.display = '';
       document.getElementById('packetInputsGroup').classList.remove('grayed-out');
+      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       saveState();
     }
   });
@@ -1992,6 +1994,8 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('skipPackets').style.display = '';
       document.querySelector('#dateRangeLabel svg').style.display = '';
       document.getElementById('packetInputsGroup').classList.remove('grayed-out');
+      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       dateRangeText.textContent = 'Date Range';
     }
   });
@@ -2030,6 +2034,19 @@ document.addEventListener('DOMContentLoaded', () => {
     dateRangeConfirmed = true; // Mark as confirmed
     document.querySelector('#dateRangeLabel svg').style.display = 'none';
     document.getElementById('packetInputsGroup').classList.add('grayed-out');
+    document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
+    document.getElementById('bpmContainer').classList.add('controls-shrunk');
+    dateRangeText.textContent = `${startDate} - ${endDate}`;
+    requestAnimationFrame(() => {
+      console.log(dateRangeText.textContent.length)
+      if (dateRangeText.textContent.length > 15) {
+        document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
+        document.getElementById('bpmContainer').classList.add('controls-shrunk');
+      } else {
+        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
+      }
+    });
     dateTimeModal.style.display = 'none';
     saveState();
     updateDateRangeModalButton();
@@ -2050,10 +2067,13 @@ document.addEventListener('DOMContentLoaded', () => {
         resetToLastPacketsMode();
         document.getElementById('packetInputsGroup').classList.remove('grayed-out');
         const dateRangeIcon = document.querySelector('#dateRangeLabel svg');
+        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
         if (dateRangeIcon) dateRangeIcon.style.display = '';
       }
     }
   });
+
 
   // ==== Popover functionality for Metadata and Packet Refresh info buttons ====
   const popover = document.getElementById('popover');

--- a/style.css
+++ b/style.css
@@ -597,7 +597,7 @@ TOP MENU
 
 #masterVolume {
   accent-color: var(--standard-blue);
-  min-width: calc(var(--tb-scale) * 130px);
+  min-width: calc(var(--tb-scale) * 145px);
   font-size: var(--tb-fs-md);
   margin: 0;
 }
@@ -649,7 +649,7 @@ TOP MENU
   height: var(--tb-h);
   background: var(--main-grey);
   border-radius: var(--tb-radius);
-  min-width: calc(var(--tb-scale) * 135px);
+  min-width: calc(var(--tb-scale) * 145px);
   position: relative;
   box-sizing: border-box;
   justify-content: center;
@@ -679,9 +679,20 @@ TOP MENU
 
 #bpm {
   accent-color: var(--standard-blue);
-  width: calc(var(--tb-scale) * 125px);
+  width: calc(var(--tb-scale) * 135px);
   height: calc(var(--tb-scale) * 6px);
   margin-top: calc(var(--tb-scale) * 0px);
+}
+
+.control-group:has(#masterVolume).controls-shrunk #masterVolume {
+  min-width: calc(var(--tb-scale) * 115px);
+  width: calc(var(--tb-scale) * 133px);
+  transition: min-width 0.2s ease, width 0.2s ease;
+}
+
+#bpmContainer.controls-shrunk #bpm {
+  width: calc(var(--tb-scale) * 125px);
+  transition: width 0.2s ease;
 }
 
 /* Speed options (1x 2x 4x 8x) */


### PR DESCRIPTION
**Overview**
--
When a date range is confirmed with a long date string (>15 chars), the master volume and BPM controls shrink slightly to prevent toolbar overflow. Controls return to original size when switching back to Last Packets mode or closing the modal without confirming.

**Fix**
--
- Added conditional width shrinking to the master volume and BPM controls when a long date range is selected. 
- Used a character length check (>15 chars) on the date range text to determine when to apply the `controls-shrunk` CSS class.
- Controls restore to original size when switching back to Last Packets mode or closing/cancelling the date range modal.

**Testing**
--
- Confirmed controls shrink when confirming a long date range (>15 chars)
- Confirmed controls do not shrink when date range text is short
- Confirmed controls restore when switching to Last Packets mode
- Confirmed controls restore when closing modal with X button
- Confirmed controls restore when clicking outside the modal

**Visuals**
--
<img width="1440" height="691" alt="Screenshot 2026-04-20 at 1 34 14 PM" src="https://github.com/user-attachments/assets/c7585529-7d30-4273-abb2-459b7a0efd88" />
<img width="1440" height="691" alt="Screenshot 2026-04-20 at 1 35 21 PM" src="https://github.com/user-attachments/assets/cfecddaf-8233-41a5-b71f-5cc587898c18" />
<img width="1440" height="691" alt="Screenshot 2026-04-20 at 1 35 42 PM" src="https://github.com/user-attachments/assets/1b0c7865-3dd7-4046-9d7c-4f0941d86ad5" />
<img width="1440" height="691" alt="Screenshot 2026-04-20 at 1 36 05 PM" src="https://github.com/user-attachments/assets/5ec495b5-21ac-414d-bd12-338d82353581" />
<img width="1440" height="691" alt="Screenshot 2026-04-20 at 1 36 17 PM" src="https://github.com/user-attachments/assets/b3ca29f1-4ec3-4f62-bef6-3f17f75edccc" />
