### PR TITLE
Fixed Merge Errors - Merging Recent Packets Update Branch into Dev

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,15 @@
 
       <!-- ========== Universal X-Axis =========== -->
       <div class="timeline-row">
-        <div class="timeline-spacer"></div>
+        <div class="timeline-spacer">
+          <div id="multiAxisToggleContainer" style="display:none;">
+            <span class="multiAxisLabel">Multi Axis</span>
+            <label class="toggle-switch">
+              <input type="checkbox" id="multiAxisToggle">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
         <div id="globalTimeline"></div>
       </div>
       <!-- =============================================== -->

--- a/index.html
+++ b/index.html
@@ -78,10 +78,10 @@
             <!-- Radio buttons to choose between last N packets or date range -->
             <div class="group" id="dataOptions">
               <!-- Option 1: Get last X packets -->
-              <label for="lastXPackets">
-                <input type="radio" id="lastXPackets" name="packetOption" value="lastXPackets" checked />
+              <label for="lastXPackets" id="lastXPacketsLabel">
+                <input type="radio" id="lastXPackets" name="packetOption" value="lastXPackets" />
                 <i data-lucide="package"></i>
-                Last Packets
+                <span id="lastPacketsText">Last Packets</span>
               </label>
               <!-- Option 2: Get packets within date range -->
               <label for="timeRange" id="dateRangeLabel">
@@ -330,6 +330,33 @@
 
       <!-- Status message notification -->
       <div id="status-message" class="status-message"></div>
+
+      <!-- Last X Packets Modal -->
+      <div id="lastXPacketsModal" class="modal" style="display: none;">
+        <div class="modal-content">
+          <span class="close-modal" id="closeLastXPacketsModal">&times;</span>
+          <h3>Select the Most Recent Packets</h3>
+          <div class="form-group">
+            <label for="lastXPacketsSelection">Retrieve Packets from the Last: </label>
+            <input type="number" id="numericalSelection" value="1" min="1" />
+            <select name="timeframes" id="timeframes">
+              <option value="minutes">Minute(s)</option>
+              <option value="hours">Hour(s)</option>
+              <option value="days">Day(s)</option>
+              <option value="weeks">Week(s)</option>
+              <option value="months">Month(s)</option>
+            </select>
+          </div>
+          <br />
+          <div class="form-group">
+            <label for="modalPrescaler1">Use of every:</label>
+            <input type="number" id="modalPrescaler1" value="1" min="1" />
+          </div>
+          <br />
+          <button id="confirmLastPackets" class="primary-btn">Apply</button>
+        </div>
+      </div>
+
       <!-- ============================================ -->
 
       <div id="metadataContainer">
@@ -337,15 +364,7 @@
 
       <!-- ========== Universal X-Axis =========== -->
       <div class="timeline-row">
-        <div class="timeline-spacer">
-          <div id="multiAxisToggleContainer" style="display:none;">
-            <span class="multiAxisLabel">Multi Axis</span>
-            <label class="toggle-switch">
-              <input type="checkbox" id="multiAxisToggle">
-              <span class="toggle-slider"></span>
-            </label>
-          </div>
-        </div>
+        <div class="timeline-spacer"></div>
         <div id="globalTimeline"></div>
       </div>
       <!-- =============================================== -->
@@ -355,6 +374,8 @@
         <span>Add Track</span>
         <i data-lucide="circle-plus" class="add-icon" ></i>
       </button>
+
+
     </main>
 
     <script type="module" src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ function captureState() {
     endTime: document.getElementById('endTime')?.value,
     dateRangeText: document.getElementById('dateRangeText')?.textContent.trim(),
     packetOption: document.querySelector('input[name="packetOption"]:checked')?.value,
+    retrievedData: retrievedData ? [...retrievedData] : null,
     retrievalParams: getRetrievalParams(),
     datasetKey: currentDatasetKey,
     hadData: !!retrievedData,
@@ -194,18 +195,20 @@ function saveState() {
   if (sensorChanging) 
     return;
 
+  // Remove any future states if we're not at the end
   if (historyIndex < historyStack.length - 1) {
     historyStack = historyStack.slice(0, historyIndex + 1);
   }
-
+  
   historyStack.push(captureState());
   historyIndex = historyStack.length - 1;
-
+  
+  // Limit history size
   if (historyStack.length > MAX_HISTORY) {
     historyStack.shift();
     historyIndex = historyStack.length - 1;
   }
-
+  
   updateUndoRedoButtons();
 }
 
@@ -1750,6 +1753,37 @@ function startFirstTimeOnboarding(options = {}) {
 // Attach a single event listener to the speedOptions container
 document.getElementById('speedOptions').addEventListener('change', handleSpeedChange);
 
+// Function to calculate the start time for the 'Last Packets' feature
+function calculateStartTime(number, timeframe) {
+  // Datetime format: YYYY-MM-DDTHH:MM
+  let startTime = new Date();
+
+  if (timeframe == 'minutes') {
+    startTime.setMilliseconds(startTime.getMilliseconds() - (number * 60 * 1000));
+  }
+
+  else if (timeframe == 'hours') {
+    startTime.setMilliseconds(startTime.getMilliseconds() - (number * 60 * 60 * 1000));
+  }
+
+  else if (timeframe == 'days') {
+    startTime.setMilliseconds(startTime.getMilliseconds() - (number * 24 * 60 * 60 * 1000));
+  }
+
+  else if (timeframe == 'weeks') {
+    startTime.setMilliseconds(startTime.getMilliseconds() - (number * 7 * 24 * 60 * 60 * 1000));
+  }
+
+  else if (timeframe == 'months') {
+    startTime.setMonth(startTime.getMonth() - number);
+  }
+
+  startTime = startTime.toISOString().slice(0, -8);
+  return startTime;
+}
+
+// console.log("Test: ", calculateStartTime(4, "months"));
+
 document.addEventListener('DOMContentLoaded', () => {
 
   const row = document.querySelector('.topmenu .row');
@@ -1871,6 +1905,14 @@ document.addEventListener('DOMContentLoaded', () => {
   for (let m of existingModules) {
     soundModules.push(m);
   }
+
+  // Toggle collapsible container for databases and devices
+  /* const dataSource = document.getElementById('dataSource');
+  const toggleButton = document.getElementById('toggleDataSource');
+  toggleButton.addEventListener('click', () => {
+    dataSource.style.display = dataSource.style.display === 'none' ? 'flex' : 'none';
+    toggleButton.textContent = dataSource.style.display === 'none' ? '▼' : '▲';
+  }); */
   
   // === POP-UP Functionally for Preset, Database, and Device ===
   const modal = document.getElementById('dataSourceModal');
@@ -1923,6 +1965,75 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  document.getElementById('numpacketsInput').style.display = 'none';
+  document.getElementById('skipPackets').style.display = 'none';
+
+  // === Last X Packets Modal Functionality === 
+  const timeRangeRadio = document.getElementById('timeRange');
+  const lastXPacketsModal = document.getElementById("lastXPacketsModal");
+  const closeLastXPacketsModal = document.getElementById("closeLastXPacketsModal");
+  const lastXPacketsRadio = document.getElementById("lastXPackets");
+  const lastXPacketsLabel = document.getElementById("lastXPacketsLabel");
+  const confirmLastPackets = document.getElementById("confirmLastPackets");
+  const lastPacketsText = document.getElementById("lastPacketsText");
+
+  // Values within the most recent packet selection
+  const numericalSelection = document.getElementById("numericalSelection");
+  const timeframes = document.getElementById("timeframes");
+  const modalPrescaler1 = document.getElementById("modalPrescaler1");
+  
+  // Track if the user has confirmed their input
+  let timeframeConfirmed = false;
+
+  // Open the modal when the user clicks the Last Packets Label
+  lastXPacketsLabel.addEventListener("click", (e) => {
+    if (e.target !== lastXPacketsRadio || lastXPacketsRadio.checked) {
+      lastXPacketsModal.style.display = "flex";
+      timeframeConfirmed = false;
+    }
+  });
+
+  // Reset values if date range is selected
+  timeRangeRadio.addEventListener("change", () => {
+    lastPacketsText.textContent = 'Last Packets';
+    numericalSelection.value = 1;
+    timeframes.value = "minutes";
+    timeframeConfirmed = false;
+    saveState();
+  });
+
+  // Close the modal and reset
+  closeLastXPacketsModal.addEventListener("click", () => {
+    lastXPacketsModal.style.display = "none";
+    
+      if (!timeframeConfirmed) {
+        lastXPacketsRadio.checked = false;
+        timeRangeRadio.checked = false;
+        lastPacketsText.textContent = 'Last Packets';
+        saveState();
+      }
+  });
+
+  
+  confirmLastPackets.addEventListener('click', () => {
+    // Validate that all values have been chosen
+    if (numericalSelection.value === '' || isNaN(numericalSelection.value) || timeframes.value == '') {
+      alert('Please select values for the most recent packets.');
+      return;
+    }
+
+    // Apply values to hidden inputs
+    startTimeInput.value = calculateStartTime(numericalSelection.value, timeframes.value);
+    endTimeInput.value = new Date().toISOString().slice(0, -8);;
+    prescalerInput.value = modalPrescaler1.value;
+
+
+    lastPacketsText.textContent = `Last ${numericalSelection.value} ${timeframes.value}`;
+    timeframeConfirmed = true; // Mark as confirmed
+    lastXPacketsModal.style.display = 'none';
+    saveState();
+  });
+
 
   // === Date/Time Range Modal Functionality ===
   const dateTimeModal = document.getElementById('dateTimeModal');
@@ -1937,9 +2048,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const modalPrescaler = document.getElementById('modalPrescaler');
   const prescalerInput = document.getElementById('prescaler');
 
+  // Track if user has confirmed their selection
+  let dateRangeConfirmed = false;
+
   // Open modal when Date Range radio is clicked (using the span to detect re-clicks)
   const dateRangeLabel = document.getElementById('dateRangeLabel');
-  const timeRangeRadio = document.getElementById('timeRange');
   updateDateRangeModalButton();
 
   dateRangeLabel.addEventListener('click', (e) => {
@@ -1959,7 +2072,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Add listener to Last Packets radio to clear date range display
-  const lastXPacketsRadio = document.getElementById('lastXPackets');
   lastXPacketsRadio.addEventListener('change', () => {
     if (lastXPacketsRadio.checked) {
       // Clear the date range display
@@ -1987,11 +2099,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Only reset if user hasn't confirmed a date range
     if (!dateRangeConfirmed) {
-      lastXPacketsRadio.checked = true;
-      document.getElementById('numpacketsInput').style.display = '';
-      document.getElementById('skipPackets').style.display = '';
-      document.querySelector('#dateRangeLabel svg').style.display = '';
-      document.getElementById('packetInputsGroup').classList.remove('grayed-out');
+      timeRangeRadio.checked = false;
+      // document.getElementById('numpacketsInput').style.display = '';
+      // document.getElementById('skipPackets').style.display = '';
       dateRangeText.textContent = 'Date Range';
     }
   });
@@ -2014,7 +2124,7 @@ document.addEventListener('DOMContentLoaded', () => {
     endTimeInput.value = modalEndTime.value;
     prescalerInput.value = modalPrescaler.value;
 
-    // Update the radio button label text to show selected dates
+        // Update the radio button label text to show selected dates
     const startDate = new Date(modalStartTime.value).toLocaleDateString('en-US', {
       month: 'numeric',
       day: 'numeric',
@@ -2039,6 +2149,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+
   // Close modal when clicking outside
   window.addEventListener('click', (e) => {
     if (e.target === dateTimeModal) {
@@ -2055,7 +2166,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // ==== Popover functionality for Metadata and Packet Refresh info buttons ====
+ // ==== Popover functionality for Metadata and Packet Refresh info buttons ====
   const popover = document.getElementById('popover');
   const popoverBody = popover.querySelector('.popover-body');
   const popoverClose = popover.querySelector('.popover-close');
@@ -2626,6 +2737,9 @@ async function retrieveData() {
   let startTime = document.getElementById('startTime').value;
   let endTime = document.getElementById('endTime').value;
 
+  let timeframes = document.getElementById('timeframes').value;
+  let numericalSelection = document.getElementById('numericalSelection').value;
+
   let packetOption = document.querySelector('input[name="packetOption"]:checked').value;
   let prescaler = document.getElementById('prescaler').value;
   let url;
@@ -2633,11 +2747,15 @@ async function retrieveData() {
 
   // Error handling for inputs
   if (packetOption === 'lastXPackets') {
-    if (x === '' || isNaN(x)) {
-      alert('Number of packets must be an integer number');
+    if (numericalSelection === '' || isNaN(numericalSelection) || timeframes == '') {
+      alert('Please select values for the most recent packets.');
       return;
     }
-    url = `/data/?database=${db}&collection=${collection}&x=${x}&prescaler=${prescaler}`;
+
+    startTime = calculateStartTime(numericalSelection, timeframes);
+    endTime = new Date().toISOString().slice(0, -8);
+
+    // url = `/data/?database=${db}&collection=${collection}&x=${x}&prescaler=${prescaler}`;
   } else if (packetOption === 'timeRange') {
     if (startTime === '' || endTime === '') {
       alert('Please enter a valid start time and end time');
@@ -2648,12 +2766,13 @@ async function retrieveData() {
       alert('End time cannot be before start time');
       return;
     }
-
-    url = `/data/?database=${db}&collection=${collection}` +
-          `&startTime=${encodeURIComponent(startTime)}` +
-          `&endTime=${encodeURIComponent(endTime)}` +
-          `&prescaler=${prescaler}`;
   }
+
+  
+  url = `/data/?database=${db}&collection=${collection}` +
+        `&startTime=${encodeURIComponent(startTime)}` +
+        `&endTime=${encodeURIComponent(endTime)}` +
+        `&prescaler=${prescaler}`;
 
   if (collection === 'default') {
     alert('Please select a device');

--- a/index.js
+++ b/index.js
@@ -2088,6 +2088,8 @@ document.addEventListener('DOMContentLoaded', () => {
       dateRangeConfirmed = false;
       document.querySelector('#dateRangeLabel svg').style.display = '';
       document.getElementById('packetInputsGroup').classList.remove('grayed-out');
+      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       saveState();
     }
   });
@@ -2100,8 +2102,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Only reset if user hasn't confirmed a date range
     if (!dateRangeConfirmed) {
       timeRangeRadio.checked = false;
-      // document.getElementById('numpacketsInput').style.display = '';
-      // document.getElementById('skipPackets').style.display = '';
+      document.querySelector('#dateRangeLabel svg').style.display = '';
+      document.getElementById('packetInputsGroup').classList.remove('grayed-out');
+      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       dateRangeText.textContent = 'Date Range';
     }
   });
@@ -2140,6 +2144,19 @@ document.addEventListener('DOMContentLoaded', () => {
     dateRangeConfirmed = true; // Mark as confirmed
     document.querySelector('#dateRangeLabel svg').style.display = 'none';
     document.getElementById('packetInputsGroup').classList.add('grayed-out');
+    document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
+    document.getElementById('bpmContainer').classList.add('controls-shrunk');
+    dateRangeText.textContent = `${startDate} - ${endDate}`;
+    requestAnimationFrame(() => {
+      console.log(dateRangeText.textContent.length)
+      if (dateRangeText.textContent.length > 15) {
+        document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
+        document.getElementById('bpmContainer').classList.add('controls-shrunk');
+      } else {
+        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
+      }
+    });
     dateTimeModal.style.display = 'none';
     saveState();
     updateDateRangeModalButton();
@@ -2161,12 +2178,15 @@ document.addEventListener('DOMContentLoaded', () => {
         resetToLastPacketsMode();
         document.getElementById('packetInputsGroup').classList.remove('grayed-out');
         const dateRangeIcon = document.querySelector('#dateRangeLabel svg');
+        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
+        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
         if (dateRangeIcon) dateRangeIcon.style.display = '';
       }
     }
   });
 
- // ==== Popover functionality for Metadata and Packet Refresh info buttons ====
+
+  // ==== Popover functionality for Metadata and Packet Refresh info buttons ====
   const popover = document.getElementById('popover');
   const popoverBody = popover.querySelector('.popover-body');
   const popoverClose = popover.querySelector('.popover-close');


### PR DESCRIPTION
**Overview**
-
Replaced the previous 'Last X Packets' feature with a more intuitive 'latest packets' retrieval function. This new function allows users to select a timeframe, and a numeric value corresponding to their selection. For example, users can select the timeframe 'months,' and enter a numeric value of '4' to retrieve all packets from the most recent 4 months.

**Import** 
-
-By modifying the user's selection, a value for the fetched URL's 'startTime' parameter is created. The 'endTime' parameter is the current datetime, down to the minute.

**Known Limitations**
-
-Many datasets have not received new data for over one year, including those within Ear2Earth's presets. Users will receive an alert when trying to retrieve data from too small of a timeframe. Additional functionality may be added to make data selection more intuitive for users.

**Visuals**
-
<img width="1888" height="973" alt="image" src="https://github.com/user-attachments/assets/17a24c39-33c8-4147-b4a1-f80a54ff5013" />
<img width="548" height="471" alt="image" src="https://github.com/user-attachments/assets/108b6759-e4d9-47a6-aaad-ba86457f1497" />
<img width="1915" height="889" alt="image" src="https://github.com/user-attachments/assets/e3e611d4-55de-4997-acec-9e17f06600d7" />
<img width="1910" height="974" alt="image" src="https://github.com/user-attachments/assets/503578a5-42bb-4934-9ce7-b6aeeb7e3eac" />

**Testing**
-
-Data available within the selected time frame -- verify JSON contains retrievedData
-Data unavailable within the selected time frame -- verify alert appears informing the user of missing data
-All timeframe options are correct -- verify calculateStartTime() returns the correct values
-'Last packets' option cannot be selected before a dataset is determined -- verify alert appears informing the user that a dataset needs to be selected