### PR TITLE
Fixed Metadata Container Modal Sizing Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -2210,12 +2210,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const metadataContent = `
-    Deployment Date: ${metadata.deployment_date}\n
-    Latitude: ${metadata.latitude}\n
-    Longitude: ${metadata.longitude}\n
-    Owner: ${metadata.owner}\n
-    `;
+  const metadataContent = 
+    `Deployment Date: ${metadata.deployment_date}\n` +
+    `Latitude: ${metadata.latitude}\n` +
+    `Longitude: ${metadata.longitude}\n` +
+    `Owner: ${metadata.owner}\n`;
 
   showPopover2(e.currentTarget, metadataContent);
   isMetadataDisplayed = true;

--- a/style.css
+++ b/style.css
@@ -1468,6 +1468,11 @@ TOP MENU
   z-index: 10002;
 }
 
+.popover2 {
+  width: auto;
+  padding-right: 15px;
+}
+
 .popover::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
**Overview**
-
A minor modal UI inconsistency was updated. Specifically, the metadata information popover had a larger width/padding than the other popovers. This UI change made its design more consistent with the others, allowing for a "cleaner" design.

**Import**
-
-The metadata retrieval functionality has not changed. A URL is generated that searches for 'metadata' type packets in the MongoDB datasets.

**Known Limitations**
-
-The 'Deployment Date' parameter has different date formats depending on the dataset.

**Visuals**
-
<img width="390" height="196" alt="image" src="https://github.com/user-attachments/assets/18f18cd6-b63d-44d7-8312-1ad76f536cdc" />

**Testing**
-
-UI is contained without unexpected padding and has a generally 'clean' look -- verify width is set to 'auto' and minor padding is added to separate the 'close' button.
