### PR TITLE
Improved top menu for new 'Last Packets' feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             </div>
 
             <!-- Dataset Date Range Display -->
-            <!-- Shows the earliest and latest available dates once a dataset is selected -->
+            <!-- Shows the earliest and latest dates of the current view once a dataset is selected -->
             <div class="date-bounds-display" id="dateBoundsDisplay">
               <span class="date-bound-item" id="earliestDateDisplay">Earliest: MM/DD/YY</span>
               <span class="date-bound-item" id="latestDateDisplay">Latest: MM/DD/YY</span>
@@ -118,7 +118,7 @@
             <input type="datetime-local" id="startTime" style="display: none;" />
             <input type="datetime-local" id="endTime" style="display: none;" />
 
-            <!-- Data Retrieval Button — commented out, retrieval now triggers automatically -->
+            <!-- Data Retrieval Button — retrieval now triggers automatically on dataset/mode confirm -->
             <!-- <button id="retrieve" class="primary-btn">Retrieve Data</button> -->
 
             <!-- ========== METADATA SECTION ========== -->

--- a/index.html
+++ b/index.html
@@ -74,6 +74,13 @@
               </button>
             </div>
 
+            <!-- Dataset Date Range Display -->
+            <!-- Shows the earliest and latest available dates once a dataset is selected -->
+            <div class="date-bounds-display" id="dateBoundsDisplay">
+              <span class="date-bound-item" id="earliestDateDisplay">Earliest: MM/DD/YY</span>
+              <span class="date-bound-item" id="latestDateDisplay">Latest: MM/DD/YY</span>
+            </div>
+
             <!-- Data Retrieval Options -->
             <!-- Radio buttons to choose between last N packets or date range -->
             <div class="group" id="dataOptions">
@@ -111,9 +118,8 @@
             <input type="datetime-local" id="startTime" style="display: none;" />
             <input type="datetime-local" id="endTime" style="display: none;" />
 
-            <!-- Data Retrieval Button -->
-            <!-- Triggers data fetch based on selected options -->
-            <button id="retrieve" class="primary-btn">Retrieve Data</button>
+            <!-- Data Retrieval Button — commented out, retrieval now triggers automatically -->
+            <!-- <button id="retrieve" class="primary-btn">Retrieve Data</button> -->
 
             <!-- ========== METADATA SECTION ========== -->
             

--- a/index.js
+++ b/index.js
@@ -1802,7 +1802,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const sections = [
     // Section 1: Dataset controls (Preset → Retrieve)
     {
-      items: ['#openPresetModal', '#dataOptions', '.packet-inputs-group', '#retrieve'],
+      items: ['#openPresetModal', '#dateBoundsDisplay', '#dataOptions', '.packet-inputs-group'],
       name: 'dataset-section'
     },
     // Section 2: Metadata
@@ -1969,6 +1969,15 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       modal.style.display = 'none';
       saveState();
+
+      // Fetch date bounds then auto-retrieve all data for the selected dataset
+      setDateBoundsForSelection(true).then(() => {
+        const startInput = document.getElementById('startTime');
+        const endInput = document.getElementById('endTime');
+        if (startInput.value && endInput.value) {
+          retrieveData();
+        }
+      });
     } else {
       alert('Please select both a database and a device');
     }
@@ -2031,12 +2040,30 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    // Apply values to hidden inputs
-    startTimeInput.value = calculateStartTime(numericalSelection.value, timeframes.value);
-    endTimeInput.value = new Date().toISOString().slice(0, -8);
-    console.log("Calculated start time: ", startTimeInput.value, "Calculated end time: ", endTimeInput.value);
+    // Apply values to hidden inputs (calculateStartTime is async)
+    calculateStartTime(numericalSelection.value, timeframes.value).then(computedStart => {
+      startTimeInput.value = computedStart;
+      // Update earliest display once resolved
+      const formatDisplayDate = (isoLocal) => {
+        const [datePart] = isoLocal.split('T');
+        const [y, m, d] = datePart.split('-');
+        return `${m}/${d}/${y.slice(2)}`;
+      };
+      const earliestEl = document.getElementById('earliestDateDisplay');
+      if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(computedStart)}`; earliestEl.classList.add('has-data'); }
+    });
+    const latestStr = new Date().toISOString().slice(0, 16);
+    endTimeInput.value = latestStr;
     prescalerInput.value = modalPrescaler1.value;
 
+    // Update latest display immediately
+    const formatDisplayDate = (isoLocal) => {
+      const [datePart] = isoLocal.split('T');
+      const [y, m, d] = datePart.split('-');
+      return `${m}/${d}/${y.slice(2)}`;
+    };
+    const latestEl = document.getElementById('latestDateDisplay');
+    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(latestStr)}`; latestEl.classList.add('has-data'); }
 
     timeframeConfirmed = true; // Mark as confirmed
     lastXPacketsModal.style.display = 'none';
@@ -2137,35 +2164,24 @@ document.addEventListener('DOMContentLoaded', () => {
     endTimeInput.value = modalEndTime.value;
     prescalerInput.value = modalPrescaler.value;
 
-        // Update the radio button label text to show selected dates
-    const startDate = new Date(modalStartTime.value).toLocaleDateString('en-US', {
-      month: 'numeric',
-      day: 'numeric',
-      year: '2-digit'
-    });
-    const endDate = new Date(modalEndTime.value).toLocaleDateString('en-US', {
-      month: 'numeric',
-      day: 'numeric',
-      year: '2-digit'
-    });
-    
-    dateRangeText.textContent = `${startDate} - ${endDate}`;
+    // Update earliest/latest display to reflect the chosen date range
+    const formatDisplayDate = (isoLocal) => {
+      const [datePart] = isoLocal.split('T');
+      const [y, m, d] = datePart.split('-');
+      return `${m}/${d}/${y.slice(2)}`;
+    };
+    const earliestEl = document.getElementById('earliestDateDisplay');
+    const latestEl = document.getElementById('latestDateDisplay');
+    if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(modalStartTime.value)}`; earliestEl.classList.add('has-data'); }
+    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(modalEndTime.value)}`; latestEl.classList.add('has-data'); }
+
+    // Keep button label static — dates now shown in the toolbar date bounds display
+    dateRangeText.textContent = 'Date Range';
     dateRangeConfirmed = true; // Mark as confirmed
     document.querySelector('#dateRangeLabel svg').style.display = 'none';
     document.getElementById('packetInputsGroup').classList.add('grayed-out');
     document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
     document.getElementById('bpmContainer').classList.add('controls-shrunk');
-    dateRangeText.textContent = `${startDate} - ${endDate}`;
-    requestAnimationFrame(() => {
-      console.log(dateRangeText.textContent.length)
-      if (dateRangeText.textContent.length > 15) {
-        document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
-        document.getElementById('bpmContainer').classList.add('controls-shrunk');
-      } else {
-        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
-        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
-      }
-    });
     dateTimeModal.style.display = 'none';
     saveState();
     updateDateRangeModalButton();
@@ -2923,7 +2939,8 @@ async function retrieveData() {
     .catch(error => console.error('Error:', error));
 }
 
-document.getElementById('retrieve').onclick = retrieveData;
+// Retrieve button removed from toolbar — retrieval now triggers automatically
+// document.getElementById('retrieve').onclick = retrieveData;
 
 // Function to save currently selected sensor and reading
 function saveSelects() {
@@ -4072,6 +4089,11 @@ async function setDateBoundsForSelection(forceAutofill = false) {
       endInput.min = '';
       endInput.max = '';
       updateDateRangeTextFromValues('', '');
+      // Clear date bounds display
+      const earliestEl = document.getElementById('earliestDateDisplay');
+      const latestEl = document.getElementById('latestDateDisplay');
+      if (earliestEl) { earliestEl.textContent = 'Earliest: MM/DD/YY'; earliestEl.classList.remove('has-data'); }
+      if (latestEl) { latestEl.textContent = 'Latest: MM/DD/YY'; latestEl.classList.remove('has-data'); }
       return;
     }
 
@@ -4085,6 +4107,17 @@ async function setDateBoundsForSelection(forceAutofill = false) {
 
     const minStr = toLocalInput(minDate);
     const maxStr = toLocalInput(maxDate);
+
+    // Update the earliest/latest toolbar display
+    const formatDisplayDate = (isoLocal) => {
+      const [datePart] = isoLocal.split('T');
+      const [y, m, d] = datePart.split('-');
+      return `${m}/${d}/${y.slice(2)}`;
+    };
+    const earliestEl = document.getElementById('earliestDateDisplay');
+    const latestEl = document.getElementById('latestDateDisplay');
+    if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(minStr)}`; earliestEl.classList.add('has-data'); }
+    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(maxStr)}`; latestEl.classList.add('has-data'); }
 
     // Set bounds
     startInput.min = minStr;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ let workspaceHasData = false
 // Track if user has confirmed a date range
 let dateRangeConfirmed = false;
 
+// Track if we're showing the automatic default 3-month view (no explicit mode selected)
+let isDefaultView = false;
+
 // Import synths and samplers
 import { samplers, fmSynths } from './instruments.js';
 
@@ -1335,27 +1338,30 @@ function isTimeRangeSelected() {
   return !!(timeRangeRadio && timeRangeRadio.checked);
 }
 
-function updateDateRangeTextFromValues(startValue, endValue) {
-  const dateRangeText = document.getElementById('dateRangeText');
-  if (!dateRangeText) return;
-
-  if (!startValue || !endValue) {
-    dateRangeText.textContent = 'Date Range';
-    return;
+// Update the earliest/latest toolbar display with formatted dates
+function updateDateBoundsDisplay(startIsoLocal, endIsoLocal) {
+  const fmt = (isoLocal) => {
+    if (!isoLocal) return 'MM/DD/YY';
+    const [datePart] = isoLocal.split('T');
+    const [y, m, d] = datePart.split('-');
+    return `${m}/${d}/${y.slice(2)}`;
+  };
+  const earliestEl = document.getElementById('earliestDateDisplay');
+  const latestEl = document.getElementById('latestDateDisplay');
+  if (earliestEl) {
+    earliestEl.textContent = startIsoLocal ? `Earliest: ${fmt(startIsoLocal)}` : 'Earliest: MM/DD/YY';
+    earliestEl.classList.toggle('has-data', !!startIsoLocal);
   }
+  if (latestEl) {
+    latestEl.textContent = endIsoLocal ? `Latest: ${fmt(endIsoLocal)}` : 'Latest: MM/DD/YY';
+    latestEl.classList.toggle('has-data', !!endIsoLocal);
+  }
+}
 
-  const startDate = new Date(startValue).toLocaleDateString('en-US', {
-    month: 'numeric',
-    day: 'numeric',
-    year: '2-digit'
-  });
-  const endDate = new Date(endValue).toLocaleDateString('en-US', {
-    month: 'numeric',
-    day: 'numeric',
-    year: '2-digit'
-  });
-
-  dateRangeText.textContent = `${startDate} - ${endDate}`;
+function updateDateRangeTextFromValues(startValue, endValue) {
+  // Button always shows static label — dates live in the toolbar date bounds display
+  const dateRangeText = document.getElementById('dateRangeText');
+  if (dateRangeText) dateRangeText.textContent = 'Date Range';
 }
 
 function resetDateRangeState() {
@@ -1950,7 +1956,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Confirm selection and close modal
-  confirmBtn.addEventListener('click', () => {
+  confirmBtn.addEventListener('click', async () => {
     const selectedDatabase = document.getElementById('databases').value;
     const selectedDevice = document.getElementById('devices').value;
     const selectedPreset = document.getElementById('modalPreset').value;
@@ -1959,10 +1965,7 @@ document.addEventListener('DOMContentLoaded', () => {
       // Update the button text to show what was selected
       if (selectedPreset !== 'default') {
         const presetData = JSON.parse(selectedPreset);
-        // Clear button
         openPresetBtn.textContent = '';
-        
-        // Add preset name
         openPresetBtn.textContent = presetData.name;
       } else {
         openPresetBtn.textContent = `${selectedDatabase} - ${selectedDevice}`;
@@ -1970,14 +1973,70 @@ document.addEventListener('DOMContentLoaded', () => {
       modal.style.display = 'none';
       saveState();
 
-      // Fetch date bounds then auto-retrieve all data for the selected dataset
-      setDateBoundsForSelection(true).then(() => {
-        const startInput = document.getElementById('startTime');
-        const endInput = document.getElementById('endTime');
-        if (startInput.value && endInput.value) {
-          retrieveData();
-        }
-      });
+      const checkedRadio = document.querySelector('input[name="packetOption"]:checked');
+      const startInput = document.getElementById('startTime');
+      const endInput = document.getElementById('endTime');
+
+      if (!checkedRadio || isDefaultView) {
+        // === DEFAULT FULL-RANGE VIEW ===
+        // Fire /date-range and /data in parallel.
+        // /date-range gives us the real min/max — we pass them directly into retrieveData
+        // via override params so there's no DOM race condition.
+        isDefaultView = true;
+
+        const db = document.getElementById('databases').value;
+        const collection = document.getElementById('devices').value;
+
+        const toLocalStr = (iso) => {
+          const d = new Date(iso);
+          const offset = d.getTimezoneOffset() * 60000;
+          const local = new Date(d.getTime() - offset);
+          return local.toISOString().slice(0, 16);
+        };
+
+        // Fetch the full date range for this dataset
+        const boundsPromise = fetch(
+          `/date-range?database=${encodeURIComponent(db)}&collection=${encodeURIComponent(collection)}`
+        )
+          .then(r => r.json())
+          .then(({ minDate, maxDate }) => {
+            if (!minDate || !maxDate) return null;
+            return { minStr: toLocalStr(minDate), maxStr: toLocalStr(maxDate) };
+          })
+          .catch(() => null);
+
+        // Kick off both simultaneously — retrieveData waits for bounds first
+        // so it can pass the real values as overrides
+        boundsPromise.then(bounds => {
+          if (!bounds) return;
+          const { minStr, maxStr } = bounds;
+
+          // Update DOM inputs and modal constraints
+          const startInput = document.getElementById('startTime');
+          const endInput = document.getElementById('endTime');
+          startInput.value = minStr;
+          endInput.value = maxStr;
+          startInput.min = minStr; startInput.max = maxStr;
+          endInput.min = minStr; endInput.max = maxStr;
+          const modalStart = document.getElementById('modalStartTime');
+          const modalEnd = document.getElementById('modalEndTime');
+          if (modalStart && modalEnd) {
+            modalStart.min = minStr; modalStart.max = maxStr;
+            modalEnd.min = minStr; modalEnd.max = maxStr;
+            modalStart.value = minStr; modalEnd.value = maxStr;
+          }
+
+          // Update the toolbar display with the real full-range dates
+          updateDateBoundsDisplay(minStr, maxStr);
+
+          // Retrieve the full dataset
+          retrieveData(minStr, maxStr);
+        });
+
+      } else {
+        // User has an explicit mode — re-retrieve with their current settings
+        retrieveData();
+      }
     } else {
       alert('Please select both a database and a device');
     }
@@ -2033,41 +2092,30 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   
-  confirmLastPackets.addEventListener('click', () => {
+  confirmLastPackets.addEventListener('click', async () => {
     // Validate that all values have been chosen
     if (numericalSelection.value === '' || isNaN(numericalSelection.value) || timeframes.value == '') {
       alert('Please select values for the most recent packets.');
       return;
     }
 
-    // Apply values to hidden inputs (calculateStartTime is async)
-    calculateStartTime(numericalSelection.value, timeframes.value).then(computedStart => {
-      startTimeInput.value = computedStart;
-      // Update earliest display once resolved
-      const formatDisplayDate = (isoLocal) => {
-        const [datePart] = isoLocal.split('T');
-        const [y, m, d] = datePart.split('-');
-        return `${m}/${d}/${y.slice(2)}`;
-      };
-      const earliestEl = document.getElementById('earliestDateDisplay');
-      if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(computedStart)}`; earliestEl.classList.add('has-data'); }
-    });
-    const latestStr = new Date().toISOString().slice(0, 16);
-    endTimeInput.value = latestStr;
+    // calculateStartTime internally calls setDateBoundsForSelection which populates modalEndTime,
+    // so we must await it first, then read modalEndTime for the correct end anchor.
+    const computedStart = await calculateStartTime(numericalSelection.value, timeframes.value);
+    const computedEnd = document.getElementById('modalEndTime').value;
+
+    startTimeInput.value = computedStart;
+    endTimeInput.value = computedEnd;
     prescalerInput.value = modalPrescaler1.value;
 
-    // Update latest display immediately
-    const formatDisplayDate = (isoLocal) => {
-      const [datePart] = isoLocal.split('T');
-      const [y, m, d] = datePart.split('-');
-      return `${m}/${d}/${y.slice(2)}`;
-    };
-    const latestEl = document.getElementById('latestDateDisplay');
-    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(latestStr)}`; latestEl.classList.add('has-data'); }
+    // Update earliest/latest display
+    updateDateBoundsDisplay(computedStart, computedEnd);
 
-    timeframeConfirmed = true; // Mark as confirmed
+    isDefaultView = false; // User has now made an explicit mode selection
+    timeframeConfirmed = true;
     lastXPacketsModal.style.display = 'none';
     saveState();
+    retrieveData();
   });
 
 
@@ -2122,10 +2170,8 @@ document.addEventListener('DOMContentLoaded', () => {
       modalPrescaler.value = '1';
       // Reset confirmation 
       dateRangeConfirmed = false;
-      document.querySelector('#dateRangeLabel svg').style.display = '';
+      // Never hide the calendar icon — it should always be visible
       document.getElementById('packetInputsGroup').classList.remove('grayed-out');
-      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
-      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       saveState();
     }
   });
@@ -2138,10 +2184,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Only reset if user hasn't confirmed a date range
     if (!dateRangeConfirmed) {
       timeRangeRadio.checked = false;
-      document.querySelector('#dateRangeLabel svg').style.display = '';
+      // Never hide the calendar icon
       document.getElementById('packetInputsGroup').classList.remove('grayed-out');
-      document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
-      document.getElementById('bpmContainer').classList.remove('controls-shrunk');
       dateRangeText.textContent = 'Date Range';
     }
   });
@@ -2164,24 +2208,15 @@ document.addEventListener('DOMContentLoaded', () => {
     endTimeInput.value = modalEndTime.value;
     prescalerInput.value = modalPrescaler.value;
 
-    // Update earliest/latest display to reflect the chosen date range
-    const formatDisplayDate = (isoLocal) => {
-      const [datePart] = isoLocal.split('T');
-      const [y, m, d] = datePart.split('-');
-      return `${m}/${d}/${y.slice(2)}`;
-    };
-    const earliestEl = document.getElementById('earliestDateDisplay');
-    const latestEl = document.getElementById('latestDateDisplay');
-    if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(modalStartTime.value)}`; earliestEl.classList.add('has-data'); }
-    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(modalEndTime.value)}`; latestEl.classList.add('has-data'); }
+    // Update earliest/latest toolbar display (dates no longer shown on the button)
+    updateDateBoundsDisplay(modalStartTime.value, modalEndTime.value);
 
-    // Keep button label static — dates now shown in the toolbar date bounds display
+    // Keep button label static — dates are now shown in the toolbar date bounds display
     dateRangeText.textContent = 'Date Range';
-    dateRangeConfirmed = true; // Mark as confirmed
-    document.querySelector('#dateRangeLabel svg').style.display = 'none';
+    isDefaultView = false; // User has now made an explicit mode selection
+    dateRangeConfirmed = true;
+    document.querySelector('#dateRangeLabel svg').style.display = '';
     document.getElementById('packetInputsGroup').classList.add('grayed-out');
-    document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
-    document.getElementById('bpmContainer').classList.add('controls-shrunk');
     dateTimeModal.style.display = 'none';
     saveState();
     updateDateRangeModalButton();
@@ -2190,61 +2225,6 @@ document.addEventListener('DOMContentLoaded', () => {
       retrieveData();
     }
   });
-
-
-  document.getElementById('confirmLastPackets').addEventListener('click', () => {
-    // if (!modalStartTime.value || !modalEndTime.value) {
-    //   alert('Error selecting a time range.');
-    //   return;
-    // }
-
-    // if (modalStartTime.value >= modalEndTime.value) {
-    //   alert('End time must be after start time');
-    //   return;
-    // }
-
-    // Apply values to hidden inputs
-    startTimeInput.value = modalStartTime.value;
-    endTimeInput.value = modalEndTime.value;
-    prescalerInput.value = modalPrescaler.value;
-
-        // Update the radio button label text to show selected dates
-    const startDate = new Date(modalStartTime.value).toLocaleDateString('en-US', {
-      month: 'numeric',
-      day: 'numeric',
-      year: '2-digit'
-    });
-    const endDate = new Date(modalEndTime.value).toLocaleDateString('en-US', {
-      month: 'numeric',
-      day: 'numeric',
-      year: '2-digit'
-    });
-    
-    // dateRangeText.textContent = `${startDate} - ${endDate}`;
-    dateRangeConfirmed = true; // Mark as confirmed
-    document.querySelector('#dateRangeLabel svg').style.display = 'none';
-    document.getElementById('packetInputsGroup').classList.add('grayed-out');
-    // document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
-    // document.getElementById('bpmContainer').classList.add('controls-shrunk');
-    // requestAnimationFrame(() => {
-    //   console.log(dateRangeText.textContent.length)
-    //   if (dateRangeText.textContent.length > 15) {
-    //     document.getElementById('masterVolume').closest('.control-group').classList.add('controls-shrunk');
-    //     document.getElementById('bpmContainer').classList.add('controls-shrunk');
-    //   } else {
-    //     document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
-    //     document.getElementById('bpmContainer').classList.remove('controls-shrunk');
-    //   }
-    // });
-    // dateTimeModal.style.display = 'none';
-    saveState();
-    // updateDateRangeModalButton();
-
-    if (lastXPacketsRadio.checked) {
-      retrieveData();
-    }
-  });
-
 
   // Close modal when clicking outside
   window.addEventListener('click', (e) => {
@@ -2256,10 +2236,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!dateRangeConfirmed) {
         resetToLastPacketsMode();
         document.getElementById('packetInputsGroup').classList.remove('grayed-out');
-        const dateRangeIcon = document.querySelector('#dateRangeLabel svg');
-        document.getElementById('masterVolume').closest('.control-group').classList.remove('controls-shrunk');
-        document.getElementById('bpmContainer').classList.remove('controls-shrunk');
-        if (dateRangeIcon) dateRangeIcon.style.display = '';
+        // Never hide the calendar icon
       }
     }
   });
@@ -2811,7 +2788,7 @@ document.getElementsByName('packetOption').forEach(radio => {
 });
 
 // Main function to retrieve data and initialize modules
-async function retrieveData() {
+async function retrieveData(overrideStart = null, overrideEnd = null) {
   // Stop audio playback
   stopSynths();
 
@@ -2833,13 +2810,13 @@ async function retrieveData() {
   let db = document.getElementById('databases').value;
   let collection = document.getElementById('devices').value;
   let x = document.getElementById('numpackets').value;
-  let startTime = document.getElementById('startTime').value;
-  let endTime = document.getElementById('endTime').value;
+  let startTime = overrideStart ?? document.getElementById('startTime').value;
+  let endTime = overrideEnd ?? document.getElementById('endTime').value;
 
   let timeframes = document.getElementById('timeframes').value;
   let numericalSelection = document.getElementById('numericalSelection').value;
 
-  let packetOption = document.querySelector('input[name="packetOption"]:checked').value;
+  let packetOption = document.querySelector('input[name="packetOption"]:checked')?.value || 'defaultView';
   let prescaler = document.getElementById('prescaler').value;
   let url;
   let metadataUrl;
@@ -2866,6 +2843,7 @@ async function retrieveData() {
       return;
     }
   }
+  // 'defaultView': startTime/endTime already set to the 3-month window by confirmDataSource
 
   
   url = `/data/?database=${db}&collection=${collection}` +
@@ -2939,7 +2917,7 @@ async function retrieveData() {
     .catch(error => console.error('Error:', error));
 }
 
-// Retrieve button removed from toolbar — retrieval now triggers automatically
+// Retrieve button removed — retrieval now triggers automatically on confirm
 // document.getElementById('retrieve').onclick = retrieveData;
 
 // Function to save currently selected sensor and reading
@@ -4089,11 +4067,7 @@ async function setDateBoundsForSelection(forceAutofill = false) {
       endInput.min = '';
       endInput.max = '';
       updateDateRangeTextFromValues('', '');
-      // Clear date bounds display
-      const earliestEl = document.getElementById('earliestDateDisplay');
-      const latestEl = document.getElementById('latestDateDisplay');
-      if (earliestEl) { earliestEl.textContent = 'Earliest: MM/DD/YY'; earliestEl.classList.remove('has-data'); }
-      if (latestEl) { latestEl.textContent = 'Latest: MM/DD/YY'; latestEl.classList.remove('has-data'); }
+      updateDateBoundsDisplay('', '');
       return;
     }
 
@@ -4108,24 +4082,14 @@ async function setDateBoundsForSelection(forceAutofill = false) {
     const minStr = toLocalInput(minDate);
     const maxStr = toLocalInput(maxDate);
 
-    // Update the earliest/latest toolbar display
-    const formatDisplayDate = (isoLocal) => {
-      const [datePart] = isoLocal.split('T');
-      const [y, m, d] = datePart.split('-');
-      return `${m}/${d}/${y.slice(2)}`;
-    };
-    const earliestEl = document.getElementById('earliestDateDisplay');
-    const latestEl = document.getElementById('latestDateDisplay');
-    if (earliestEl) { earliestEl.textContent = `Earliest: ${formatDisplayDate(minStr)}`; earliestEl.classList.add('has-data'); }
-    if (latestEl) { latestEl.textContent = `Latest: ${formatDisplayDate(maxStr)}`; latestEl.classList.add('has-data'); }
-
     // Set bounds
     startInput.min = minStr;
     startInput.max = maxStr;
     endInput.min = minStr;
     endInput.max = maxStr;
 
-    // Autofill values if source changed in date-range mode, or if user has no confirmed custom range.
+    // Autofill input values only when forceAutofill is set (i.e. on fresh dataset confirm)
+    // Never overwrite values after a user selection has been made
     if (forceAutofill || !dateRangeConfirmed) {
       startInput.value = minStr;
       endInput.value = maxStr;

--- a/style.css
+++ b/style.css
@@ -21,9 +21,9 @@
   --tb-scale: 1;
 
   --tb-h:        calc(var(--tb-scale) * 58px);
-  --tb-fs:       calc(var(--tb-scale) * 12.5px);
-  --tb-fs-sm:    calc(var(--tb-scale) * 12.5px);
-  --tb-fs-md:    calc(var(--tb-scale) * 12.5px);
+  --tb-fs:       calc(var(--tb-scale) * 13px);
+  --tb-fs-sm:    calc(var(--tb-scale) * 13px);
+  --tb-fs-md:    calc(var(--tb-scale) * 13px);
   --tb-icon-sm:  calc(var(--tb-scale) * 15px);
   --tb-icon-md:  calc(var(--tb-scale) * 18px);
   --tb-icon-lg:  calc(var(--tb-scale) * 20px);
@@ -284,7 +284,6 @@ TOP MENU
    TOP MENU —  BUTTON
 ===================================================== */
 #openPresetModal {
-  width:  calc(var(--tb-scale) * 100px);
   height: var(--tb-h);
   padding: 0;
   border: none;
@@ -301,6 +300,11 @@ TOP MENU
   justify-content: center;
   gap: calc(var(--tb-scale) * 4px);
   text-wrap: wrap;
+}
+
+#openPresetModal,
+#retrieve {
+  width: calc(var(--tb-scale) * 105px);
 }
 
 #openPresetModal:hover { 
@@ -349,7 +353,7 @@ TOP MENU
   display: flex;
   align-items: center;
   gap: calc(var(--tb-scale) * 5px);
-  padding: 0 calc(var(--tb-scale) * 8px);
+  padding: 0 calc(var(--tb-scale) * 10px);
   cursor: pointer;
   font-size: var(--tb-fs);
   background: var(--main-grey);
@@ -411,7 +415,6 @@ TOP MENU
   white-space: nowrap;
   box-sizing: border-box;
   width: calc(var(--tb-scale) * 128px);
-  opacity: 0.5;
 }
 
 .date-bound-item.has-data {
@@ -485,10 +488,9 @@ TOP MENU
    TOP MENU — PRIMARY BUTTONS (RETRIEVE, ETC.)
 ===================================================== */
 .primary-btn {
-  width:  calc(var(--tb-scale) * 70px);
   height: var(--tb-h);
   padding: calc(var(--tb-scale) * 5px);
-  font-size: var(--tb-fs) !important;
+  font-size: var(--tb-fs);
   background: var(--standard-blue);
   color: #fff;
   border: none;
@@ -519,7 +521,7 @@ TOP MENU
   justify-content: center;
   gap: calc(var(--tb-scale) * 4px);
   font-size: var(--tb-fs);
-  width:  calc(var(--tb-scale) * 100px);
+  width:  calc(var(--tb-scale) * 105px);
   height: var(--tb-h);
 }
 
@@ -634,6 +636,9 @@ TOP MENU
   padding: 0 var(--tb-pad);
   gap: calc(var(--tb-scale) * 12px);
   height: var(--tb-h);
+  width: calc(var(--tb-scale) * 175px);
+  box-sizing: border-box;
+  flex-shrink: 0;
 }
 
 .control-group:has(#masterVolume) label {
@@ -644,7 +649,9 @@ TOP MENU
 
 #masterVolume {
   accent-color: var(--standard-blue);
-  min-width: calc(var(--tb-scale) * 145px);
+  width: calc(var(--tb-scale) * 135px);
+  max-width: calc(var(--tb-scale) * 135px);
+  flex-shrink: 0;
   font-size: var(--tb-fs-md);
   margin: 0;
 }
@@ -696,7 +703,7 @@ TOP MENU
   height: var(--tb-h);
   background: var(--main-grey);
   border-radius: var(--tb-radius);
-  min-width: calc(var(--tb-scale) * 145px);
+  min-width: calc(var(--tb-scale) * 173px);
   position: relative;
   box-sizing: border-box;
   justify-content: center;
@@ -884,7 +891,7 @@ TOP MENU
   cursor: pointer;
   font-size: var(--tb-fs);
   height: var(--tb-h);
-  width:  calc(var(--tb-scale) * 100px);
+  width:  calc(var(--tb-scale) * 105px);
   transition: all 0.2s ease;
   white-space: nowrap;
   flex-direction: column;
@@ -920,7 +927,7 @@ TOP MENU
   transition: all 0.2s ease;
   white-space: nowrap;
   height: var(--tb-h);
-  width:  calc(var(--tb-scale) * 100px);
+  width:  calc(var(--tb-scale) * 105px);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -1411,16 +1418,18 @@ TOP MENU
 }
 
 .modal-content #confirmDataSource {
-  width: 96%;
+  width: 100%;
   height: auto;
   padding: 12px;
-  margin: 10px;
   margin-top: 20px;
+  margin-left: 0;
+  margin-right: 0;
   background-color: var(--standard-blue);
   color: #fff;
   border: 1px solid var(--standard-blue);
   border-radius: 3px;
   font-size: 14px;
+  box-sizing: border-box;
 }
 
 .modal-form {
@@ -1466,16 +1475,18 @@ TOP MENU
 }
 
 .modal-content #confirmDateTime, .modal-content #confirmLastPackets {
-  width: 96%;
+  width: 100%;
   height: auto;
   padding: 12px;
-  margin: 10px;
   margin-top: 20px;
+  margin-left: 0;
+  margin-right: 0;
   background-color: var(--standard-blue);
   color: #fff;
   border: 1px solid var(--standard-blue);
   border-radius: 3px;
   font-size: 14px;
+  box-sizing: border-box;
 }
 
 /* =====================================================

--- a/style.css
+++ b/style.css
@@ -388,6 +388,37 @@ TOP MENU
 }
 
 /* =====================================================
+   TOP MENU — DATE BOUNDS DISPLAY
+===================================================== */
+.date-bounds-display {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--tb-scale) * 3px);
+  height: var(--tb-h);
+  align-items: stretch;
+}
+
+.date-bound-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 calc(var(--tb-scale) * 10px);
+  background: var(--main-grey);
+  border-radius: var(--tb-radius);
+  height: calc(50% - calc(var(--tb-scale) * 1.5px));
+  font-size: var(--tb-fs);
+  color: black;
+  white-space: nowrap;
+  box-sizing: border-box;
+  width: calc(var(--tb-scale) * 128px);
+  opacity: 0.5;
+}
+
+.date-bound-item.has-data {
+  opacity: 1;
+}
+
+/* =====================================================
    TOP MENU — PACKET INPUTS
 ===================================================== */
 .packet-inputs-group {


### PR DESCRIPTION
Note: Due to limited time, multiple features were implemented and multiple bugs were fixed from previous dev merge
Closes #138, Closes #123, Closes #122 

## New Features

- Added Earliest/Latest date display in the toolbar showing the current data window at a glance
- Auto-plot on dataset select — picking a dataset now immediately fetches and plots the full date range, no extra clicks needed
- Removed the Retrieve Data button from the toolbar since retrieval now triggers automatically
- Last Packets and Date Range modes now update the earliest/latest display to reflect whatever window the user selected

## UX/Flow Improvements

- Reordered the toolbar: dataset select → date bounds → Last Packets/Date Range
- Default view shows the full dataset range on first load
- Switching datasets preserves your mode selection (Last Packets or Date Range) if you had one set
- Date Range button now always shows static "Date Range" text — dates moved to the new display

## Bugs Fixed

- Date bounds display was being overwritten after every retrieval by setDateBoundsForSelection
- calculateStartTime was async but called without await, causing [object Promise] in URLs
- Parallel fetch race condition where /data fired before date bounds were ready
- Latest date in Last Packets mode was showing today's date instead of the dataset's actual max
- Calendar icon on Date Range button randomly disappearing
- controls-shrunk class incorrectly resizing Master Volume and BPM when Date Range was selected
- Date text appearing on the Date Range button even after we moved dates to the new display
- Duplicate confirmLastPackets event listener causing conflicts

## CSS Polish

- Matched Master Volume and BPM slider lengths
- Increased padding on toolbar buttons (Select a Preset, View Metadata, Last Packets, Date Range, Packet Refresh, Clear Space)
- Fixed modal Confirm/Retrieve buttons back to full width
- Removed grey-out on earliest/latest date items