### PR TITLE
Fix modal label text and revert button label to "Select a Database"

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
             <div class="group">
               <button id="openPresetModal" class="primary-btn">
                 <i data-lucide="folder-search"></i>
-                Select a Preset
+                Select a Database
               </button>
             </div>
 
@@ -236,6 +236,12 @@
         <div class="modal-content">
           <span class="close-modal">&times;</span>
           <h3>Configure Data Source</h3>
+          
+          <div class="modal-text"> 
+            <label>
+              Please select a preset or choose a database and device to retrieve data from. 
+            </label>
+          </div>
 
           <!-- Preset selection in modal -->
           <div id="presetElements">
@@ -243,6 +249,12 @@
             <select id="modalPreset">
               <option value="default">Select a Preset</option>
             </select>
+          </div>
+
+          <div class="separator">
+            <hr />
+            <span>OR</span>
+            <hr />
           </div>
           
           <div id="databaseElements">

--- a/style.css
+++ b/style.css
@@ -304,7 +304,7 @@ TOP MENU
 
 #openPresetModal,
 #retrieve {
-  width: calc(var(--tb-scale) * 105px);
+  width: calc(var(--tb-scale) * 115px);
 }
 
 #openPresetModal:hover { 
@@ -927,7 +927,7 @@ TOP MENU
   transition: all 0.2s ease;
   white-space: nowrap;
   height: var(--tb-h);
-  width:  calc(var(--tb-scale) * 105px);
+  width:  calc(var(--tb-scale) * 95px);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -1377,7 +1377,7 @@ TOP MENU
 
 .modal-content h3 {
   margin-top: 0;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   color: #333;
   font-size: 20px;
 }
@@ -1407,6 +1407,14 @@ TOP MENU
   font-weight: bold;
   font-size: 13px;
 }
+
+.modal-text label {
+  font-size: var(--tb-fs);
+  color: #afafaf;
+  margin-bottom: calc(var(--tb-scale) * 12px);
+  font-style: italic;
+  font-weight: 300;
+} 
 
 .modal-content select {
   width: 100%;


### PR DESCRIPTION
**Overview**
-
This PR makes two small UI updates to the Configure Data Source modal

**What changed**
--
- Reverted the toolbar button label from "Select a Preset" back to "Select a Database"
- Added a helper text label inside the Configure Data Source modal that reads: "Please select a preset or choose a database and device to retrieve data from."
- Styled the helper text to be light weight, italic, and muted gray to visually distinguish it from the other modal labels

**Visuals**
-
**Before:**
<img width="115" height="71" alt="Screenshot 2026-05-04 at 1 19 34 PM" src="https://github.com/user-attachments/assets/f68bee18-4d01-48ad-b652-225ce6da1edb" />
<img width="475" height="450" alt="Screenshot 2026-05-04 at 1 19 14 PM" src="https://github.com/user-attachments/assets/867c842f-48f6-4683-9d89-357859c9441e" />

**After:**
<img width="125" height="71" alt="Screenshot 2026-05-04 at 1 20 08 PM" src="https://github.com/user-attachments/assets/26244e14-f4c5-4e31-a7fd-37e48dfd7daf" />
<img width="473" height="517" alt="Screenshot 2026-05-04 at 1 20 27 PM" src="https://github.com/user-attachments/assets/8ce0e57f-0dd8-4585-9ba6-f4300b1d3298" />

