### PR TITLE
Updated specific modals and their relative descriptions per project partner's request

### DIFF
--- a/index.js
+++ b/index.js
@@ -1457,7 +1457,7 @@ function startFirstTimeOnboarding(options = {}) {
     {
       selectors: ['#numericalSelection', '#timeframes', '#modalPrescaler1'],
       title: 'Last Packets Setup',
-      text: 'Set a time window relative to the most recent packet in your dataset (e.g., last 2 hours). Adjust the prescaler to use every Nth packet.',
+      text: 'Set a time window relative to the most recent packet in your dataset (e.g., last 2 hours). Adjust "Use of every" to sample every Nth packet.',
       beforeShow: () => {
         document.getElementById('lastXPackets').checked = true;
       },
@@ -1478,7 +1478,7 @@ function startFirstTimeOnboarding(options = {}) {
     {
       selectors: ['#dateRangeLabel'],
       title: 'Date Range',
-      text: 'Click Date Range to open the date/time picker and retrieve data for a specific time window.',
+      text: 'Or click Date Range to open the date/time picker and retrieve data for a specific time window.',
       showDataSourceModal: false,
       showDateTimeModal: false,
       showLastXPacketsModal: false
@@ -1540,7 +1540,7 @@ function startFirstTimeOnboarding(options = {}) {
     {
       selectors: ['.soundModule .moduleBottomOptions'],
       title: 'Advanced Sound Controls',
-      text: 'Tonic: center pitch (key). Scale: an arrangement of pitches giving the music its character (e.g., happy or sad). Tessitura: the pitch register of the instrument (high or low). Sustain Notes: notes continue sounding until a new note plays. Sound Type: the instrument.',
+      text: 'Tonic: center pitch (key). Scale: an arrangement of pitches giving the music its character (e.g., happy or sad). Register: the range of how high or low the instrument will play. Sustain Notes: notes continue sounding until a new note plays. Sound Type: the instrument.',
       beforeShow: () => {
         const collapseBtn = document.querySelector('.soundModule .collapse-btn');
         const options = document.querySelector('.soundModule .moduleBottomOptions');
@@ -1563,7 +1563,7 @@ function startFirstTimeOnboarding(options = {}) {
     {
       selectors: ['#multiAxisToggleContainer'],
       title: 'Multi Axis',
-      text: 'This toggle appears in the timeline once a track has data plotted. Enable it to give each track its own y-axis scale. The secondary axis and its sensor/reading dropdowns appear after a second track has readings assigned.',
+      text: 'Once data is plotted, this toggle lets each track use its own y-axis scale. The secondary axis controls appear when a second track has a sensor and reading selected.',
       beforeShow: () => {
         const container = document.getElementById('multiAxisToggleContainer');
         if (container) container.style.display = '';


### PR DESCRIPTION
### **Overview**
Some of the descriptions needed further clarification and wording changes to improve clarity for the user.

### **What Changed**
- Wording changed from "Use of every" instead Tof prescaler
- Added the word "OR" to the date range modal
- Renamed "essitura" in the sound controls modal to "Register"
- Added clarity to the 'Multi-Axis" modal
- Clarified the new data retrieval functionality (can retrieve data directly within the pop-up menus)
- Accounted for new 'Last Packets'  and soon-to-be implemented 'Packet Refresh' functionality

### **Visuals**
**SS 1:**
<img width="793" height="302" alt="Screenshot 2026-05-06 100705" src="https://github.com/user-attachments/assets/ce922788-e051-4754-ae66-8002b64b849f" />
**SS 2:**
<img width="1186" height="372" alt="Screenshot 2026-05-06 100656" src="https://github.com/user-attachments/assets/85a53187-ebfb-4f87-a543-b86863d4d6ad" />
**SS 3:**
<img width="1012" height="294" alt="Screenshot 2026-05-06 100646" src="https://github.com/user-attachments/assets/d4df4c5e-b116-45c4-a1ba-e45a1de0c2cc" />
**SS 4:**
<img width="1668" height="689" alt="Screenshot 2026-05-06 100612" src="https://github.com/user-attachments/assets/974d0c37-226e-49f0-bc90-fe527565fc0f" />
**SS 5:**
<img width="795" height="483" alt="Screenshot 2026-05-06 100445" src="https://github.com/user-attachments/assets/f6ad9ecc-f9b4-4e3b-bd63-9d1d4860e699" />
